### PR TITLE
Support Python 3

### DIFF
--- a/directives.py
+++ b/directives.py
@@ -362,7 +362,7 @@ class ListTable(Table):
             header_rows = self.options.get('header-rows', 0)
             stub_columns = self.options.get('stub-columns', 0)
             self.check_table_dimensions(table_data, header_rows, stub_columns)
-        except SystemMessagePropagation, detail:
+        except SystemMessagePropagation as detail:
             return [detail.args[0]]
         #table_node = self.build_table_from_list(table_data, col_widths,
         #                                        header_rows, stub_columns)


### PR DESCRIPTION
Hi,

I found this project really useful for me but causing an error on Python 3.  This change is just a one-line fix to make it runnable on both Python 2 and 3.  I verified that Python 2.7.10 and Python 3.4.3 executed directives.py without errors.

Please consider introducing this, thanks!